### PR TITLE
Reverse Component Icon Draw

### DIFF
--- a/HierarchyDecorator/Scripts/Editor/Hierarchy/ComponentIconInfo.cs
+++ b/HierarchyDecorator/Scripts/Editor/Hierarchy/ComponentIconInfo.cs
@@ -35,8 +35,9 @@ namespace HierarchyDecorator
             componentTypes.Clear ();
 
             Component[] components = instance.GetComponents<Component> ();
-            foreach (Component component in components)
+            for (int i = components.Length; i-- > 0;)
             {
+                var component = components[i];
                 if (component == null)
                 {
                     continue;


### PR DESCRIPTION
Draw Component Icons in the order in which they are displayed in the Inspector.