### PR TITLE
Added force monobehaviour display option addressing feature request 65

### DIFF
--- a/HierarchyDecorator/Scripts/Editor/Data/ComponentData.cs
+++ b/HierarchyDecorator/Scripts/Editor/Data/ComponentData.cs
@@ -8,6 +8,7 @@ namespace HierarchyDecorator
     public class ComponentData
     {
         public bool showMissingScriptsWarning;
+        public bool forceAllScriptsDisplay;
 
         // Collecitons
         public List<ComponentType> unityComponents = new List<ComponentType> ();

--- a/HierarchyDecorator/Scripts/Editor/Hierarchy/Info/ComponentIconInfo.cs
+++ b/HierarchyDecorator/Scripts/Editor/Hierarchy/Info/ComponentIconInfo.cs
@@ -63,13 +63,17 @@ namespace HierarchyDecorator
                     continue;
                 }
 
-                if (type.IsSubclassOf (typeof (MonoBehaviour)) && settings.componentData.FindCustomComponentFromType(type, out CustomComponentType componentType))
+                if (type.IsSubclassOf(typeof(MonoBehaviour)) && settings.componentData.forceAllScriptsDisplay)
                 {
-                    DrawMonobehaviour (rect, component, componentType, settings);
+                    DrawMonobehaviour(rect, component, settings);
+                }
+                else if (type.IsSubclassOf(typeof(MonoBehaviour)) && settings.componentData.FindCustomComponentFromType(type, out CustomComponentType componentType))
+                {
+                    DrawMonobehaviour(rect, component, componentType, settings);
                 }
                 else
                 {
-                    DrawComponent (rect, type, instance, settings);
+                    DrawComponent(rect, type, instance, settings);
                 }
             }
         }
@@ -84,8 +88,7 @@ namespace HierarchyDecorator
 
         private void DrawMonobehaviour(Rect rect, Component component, CustomComponentType componentType, Settings settings)
         {
-            Type type = component.GetType ();
-
+            
             if (!settings.globalData.showAllComponents)
             {
                 if (componentType.script == null)
@@ -99,11 +102,20 @@ namespace HierarchyDecorator
                 }
             }
 
-            string path = AssetDatabase.GetAssetPath (MonoScript.FromMonoBehaviour (component as MonoBehaviour));
-            GUIContent content = new GUIContent (AssetDatabase.GetCachedIcon (path));
+            DrawFetchedMonoBehaviourInfo(rect, component, settings);
+        }
 
-            componentTypes.Add (type);
-            DrawComponentIcon (rect, content, type);
+        private void DrawMonobehaviour(Rect rect, Component component, Settings settings) => DrawFetchedMonoBehaviourInfo(rect, component, settings);
+
+        private void DrawFetchedMonoBehaviourInfo(Rect rect, Component component, Settings settings)
+        {
+            Type type = component.GetType();
+
+            string path = AssetDatabase.GetAssetPath(MonoScript.FromMonoBehaviour(component as MonoBehaviour));
+            GUIContent content = new GUIContent(AssetDatabase.GetCachedIcon(path));
+
+            componentTypes.Add(type);
+            DrawComponentIcon(rect, content, type);
         }
 
         private void DrawComponent(Rect rect, Type type, GameObject instance, Settings settings)

--- a/HierarchyDecorator/Scripts/Editor/Tabs/IconTab.cs
+++ b/HierarchyDecorator/Scripts/Editor/Tabs/IconTab.cs
@@ -30,6 +30,7 @@ namespace HierarchyDecorator
         // References
         private readonly SerializedProperty showAllProperty;
         private readonly SerializedProperty showMissingProperty;
+        private readonly SerializedProperty forceShowAllScriptsProperty;
 
         private readonly SerializedProperty serializedCustomComponents;
         private readonly SerializedProperty serializedUnityComponents;
@@ -46,6 +47,7 @@ namespace HierarchyDecorator
             // Setup References
             showAllProperty = serializedSettings.FindProperty ("globalData.showAllComponents");
             showMissingProperty = serializedTab.FindPropertyRelative ("showMissingScriptsWarning");
+            forceShowAllScriptsProperty = serializedTab.FindPropertyRelative("forceAllScriptsDisplay");
 
             serializedUnityComponents = serializedTab.FindPropertyRelative ("unityComponents");
             serializedCustomComponents = serializedTab.FindPropertyRelative ("customComponents");
@@ -66,6 +68,7 @@ namespace HierarchyDecorator
 
             EditorGUI.BeginChangeCheck ();
             EditorGUILayout.PropertyField (showMissingProperty);
+            EditorGUILayout.PropertyField (forceShowAllScriptsProperty);
             if (EditorGUI.EndChangeCheck ())
             {
                 serializedSettings.ApplyModifiedProperties ();


### PR DESCRIPTION
This solves feature request 65: Show MonoBehaviour script icon for objects that contain scripts. It adds the checkmark that would force display of each and every MonoBehaviour. Workflow: user checks this checkbox if they want to display all scripts, user keeps this checkbox unchecked and specifies custom scripts if they would like to display only some specific scripts.