### PR TITLE
Fix: NullException on Missing Script Components

### DIFF
--- a/HierarchyDecorator/Scripts/Editor/ComponentItem.cs
+++ b/HierarchyDecorator/Scripts/Editor/ComponentItem.cs
@@ -74,7 +74,7 @@ namespace HierarchyDecorator
         {
             // Default as enabled 
 
-            if (!Type.HasToggle)
+            if (Type == null || !Type.HasToggle)
             {
                 return true;
             }
@@ -105,7 +105,7 @@ namespace HierarchyDecorator
 
         public void UpdateActiveState()
         {
-            if (IsNullComponent || !Type.HasToggle)
+            if (Type == null || !Type.HasToggle)
             {
                 return;
             }

--- a/HierarchyDecorator/Scripts/Editor/ComponentItem.cs
+++ b/HierarchyDecorator/Scripts/Editor/ComponentItem.cs
@@ -105,7 +105,7 @@ namespace HierarchyDecorator
 
         public void UpdateActiveState()
         {
-            if (!Type.HasToggle)
+            if (IsNullComponent || !Type.HasToggle)
             {
                 return;
             }

--- a/HierarchyDecorator/Scripts/Editor/ComponentItem.cs
+++ b/HierarchyDecorator/Scripts/Editor/ComponentItem.cs
@@ -43,6 +43,13 @@ namespace HierarchyDecorator
             }
 
             Type = GetComponentInfo(HierarchyDecorator.Settings);
+
+            if (Type == null)
+            {
+                
+                IsNullComponent = true;
+            }
+            
             Active = GetActiveState();
         }
 
@@ -55,6 +62,9 @@ namespace HierarchyDecorator
 
         private ComponentType GetComponentInfo(Settings settings)
         {
+            if (IsNullComponent)
+                return null;
+            
             var type = Component.GetType();
             if (settings.Components.TryGetComponent(type, out ComponentType c))
             {
@@ -74,7 +84,7 @@ namespace HierarchyDecorator
         {
             // Default as enabled 
 
-            if (Type == null || !Type.HasToggle)
+            if (IsNullComponent || !Type.HasToggle)
             {
                 return true;
             }
@@ -105,7 +115,7 @@ namespace HierarchyDecorator
 
         public void UpdateActiveState()
         {
-            if (Type == null || !Type.HasToggle)
+            if (IsNullComponent || !Type.HasToggle)
             {
                 return;
             }

--- a/HierarchyDecorator/Scripts/Editor/Hierarchy/Info/ComponentIconInfo.cs
+++ b/HierarchyDecorator/Scripts/Editor/Hierarchy/Info/ComponentIconInfo.cs
@@ -167,7 +167,7 @@ namespace HierarchyDecorator
 
         private bool CanShow(ComponentItem item, Settings settings)
         {
-            if (item.Type == null || item.Type.Excluded)
+            if (item.IsNullComponent || item.Type.Excluded)
             {
                 return false;
             }

--- a/HierarchyDecorator/Scripts/Editor/Hierarchy/Info/ComponentIconInfo.cs
+++ b/HierarchyDecorator/Scripts/Editor/Hierarchy/Info/ComponentIconInfo.cs
@@ -167,7 +167,7 @@ namespace HierarchyDecorator
 
         private bool CanShow(ComponentItem item, Settings settings)
         {
-            if (item.Type.Excluded)
+            if (item.Type == null || item.Type.Excluded)
             {
                 return false;
             }


### PR DESCRIPTION
Missing Script Components on GameObjects throw NullException when UpdateActiveState is called, resulting in a broken Hierarchy Window from this GameObject onward