### PR TITLE
Fix breadcrumbs last sibling bug when deleting last sibling

### DIFF
--- a/HierarchyDecorator/Scripts/Editor/HierarchyCache.cs
+++ b/HierarchyDecorator/Scripts/Editor/HierarchyCache.cs
@@ -183,10 +183,10 @@ namespace HierarchyDecorator
 
                 int id = data.ID;
 
-                //if (Roots.Contains(data.ID))
-                //{
-                //    Roots.Remove(data.ID);
-                //}
+                if (Roots.Contains(data.ID))
+                {
+                    Roots.Remove(data.ID);
+                }
 
                 lookup.Remove(id);
                 return true;


### PR DESCRIPTION
Fixes #99

Uncomment the code in the Remove method to update the root IDs correctly. Ensure the Roots list is updated correctly in the Remove method