### PR TITLE
Add feature and toggle for no space after prefix

### DIFF
--- a/HierarchyDecorator/Scripts/Editor/Data/HierarchyStyleData.cs
+++ b/HierarchyDecorator/Scripts/Editor/Data/HierarchyStyleData.cs
@@ -118,19 +118,11 @@ namespace HierarchyDecorator
                 return false;
             }
 
-            if (prefix.Contains (" "))
-            {
-                prefix = prefix.TrimStart ().Split (' ')[0];
-            }
-
             for (int i = 0; i < styles.Count; i++)
             {
                 style = styles[i];
-
-                if (prefix.Equals (style.prefix))
-                {
+                if (CheckPrefix(prefix, style))
                     return true;
-                }
             }
 
             style = null;
@@ -139,17 +131,10 @@ namespace HierarchyDecorator
 
         public bool HasStyle(string prefix)
         {
-            if (prefix.Contains (" "))
-            {
-                prefix = prefix.TrimStart ().Split (' ')[0];
-            }
-
             for (int i = 0; i < styles.Count; i++)
             {
-                if (styles[i].prefix == prefix)
-                {
+                if (CheckPrefix(prefix, styles[i]))
                     return true;
-                }
             }
 
             return false;
@@ -178,6 +163,20 @@ namespace HierarchyDecorator
 
                 return styles[i];
             }
+        }
+
+        private bool CheckPrefix(string targetPrefix, HierarchyStyle style)
+        {
+            if (targetPrefix.StartsWith (style.prefix))
+            {
+                if (style.noSpaceAfterPrefix)
+                    return true;
+
+                if (targetPrefix[style.prefix.Length] == ' ')
+                    return true;
+            }
+
+            return false;
         }
     }
 }

--- a/HierarchyDecorator/Scripts/Editor/Data/Types/HierarchyStyle.cs
+++ b/HierarchyDecorator/Scripts/Editor/Data/Types/HierarchyStyle.cs
@@ -29,6 +29,7 @@ namespace HierarchyDecorator
     public class HierarchyStyle
     {
         public string prefix = "<PREFIX>";
+        public bool noSpaceAfterPrefix = false;
         public string name = "New Style";
 
         public Font font = null;

--- a/HierarchyDecorator/Scripts/Editor/Tabs/StyleTab.cs
+++ b/HierarchyDecorator/Scripts/Editor/Tabs/StyleTab.cs
@@ -27,7 +27,7 @@ namespace HierarchyDecorator
         private readonly Color OUTLINE_COLOR = new Color (0.15f, 0.15f, 0.15f, 1f);
 
         private readonly GUIContent[] Modes = { new GUIContent("Light Mode"), new GUIContent("Dark Mode") };
-        private readonly string[] SettingList = { "prefix", "name", "font", "fontSize", "fontStyle", "fontAlignment",  "textFormatting" };
+        private readonly string[] SettingList = { "prefix", "noSpaceAfterPrefix", "name", "font", "fontSize", "fontStyle", "fontAlignment",  "textFormatting" };
 
         public StyleTab(Settings settings, SerializedObject serializedSettings) : base (settings, serializedSettings, "styleData", "Visual", "d_InputField Icon")
         {


### PR DESCRIPTION
This pull request will allow for the prefix to be entered without spaces. A toggle is added for backwards compatibility.

![image](https://github.com/user-attachments/assets/6e2deb1f-dd4a-46a2-9010-39d14a0ee1e1)
![image](https://github.com/user-attachments/assets/c448a87d-de44-4b54-9134-b42d1d7d0087)
