### PR TITLE
Add context menu to ComponentIconInfo

### DIFF
--- a/HierarchyDecorator/Scripts/Editor/Hierarchy/Info/ComponentIconInfo.cs
+++ b/HierarchyDecorator/Scripts/Editor/Hierarchy/Info/ComponentIconInfo.cs
@@ -2,8 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Reflection;
+using Object = UnityEngine.Object;
 using UnityEditor;
 using UnityEngine;
+using System.ComponentModel;
 
 namespace HierarchyDecorator
 {
@@ -125,6 +128,8 @@ namespace HierarchyDecorator
 
         private void DrawComponentIcon(Rect rect, ComponentItem item)
         {
+            DrawContextMenu(rect, item);
+
             if (item.CanToggle)
             {
                 DrawComponentToggle(rect, item);
@@ -139,7 +144,7 @@ namespace HierarchyDecorator
         {
             Event ev = Event.current;
 
-            if (ev.type == EventType.MouseDown && rect.Contains(ev.mousePosition))
+            if (ev.type == EventType.MouseDown && ev.button == 0 && rect.Contains(ev.mousePosition))
             {
                 item.ToggleActive();
                 ev.Use();
@@ -171,6 +176,18 @@ namespace HierarchyDecorator
         private void DrawIcon(Rect rect, GUIContent content)
         {
             GUI.Label(rect, content, Style.ComponentIconStyle);
+        }
+
+        private void DrawContextMenu(Rect rect, ComponentItem item)
+        {
+            Event ev = Event.current;
+
+            if (ev.type == EventType.MouseDown && ev.button == 1 && rect.Contains(ev.mousePosition))
+            {
+                var method = typeof(EditorUtility).GetMethod("DisplayObjectContextMenu", BindingFlags.NonPublic | BindingFlags.Static, null, new Type[] { typeof(Rect), typeof(Object), typeof(int) }, null);
+                method.Invoke(null, new object[] { rect, item.Component, 0 });
+                ev.Use();
+            }
         }
 
         // Helpers


### PR DESCRIPTION
![ContextMenu](https://github.com/user-attachments/assets/fabe0d27-07a4-4f15-85b2-3a2b6d7b3529)

When using the 'Stack Duplicate Icons' setting, this feature is disabled like a toggle function