### PR TITLE
Click To Toggle Components feature

### DIFF
--- a/HierarchyDecorator/Scripts/Editor/ComponentItem.cs
+++ b/HierarchyDecorator/Scripts/Editor/ComponentItem.cs
@@ -6,10 +6,9 @@ namespace HierarchyDecorator
     public class ComponentItem
     {
         // --- Properties
-        public Settings HDSettings => HierarchyDecorator.Settings;
 
         public Component Component { get; private set; }
-        public ComponentType Type => GetComponentInfo(HDSettings);
+        public ComponentType Type => GetComponentInfo(HierarchyDecorator.Settings);
         public bool IsNullComponent { get; private set; }
 
         public readonly bool IsBehaviour;
@@ -21,8 +20,7 @@ namespace HierarchyDecorator
 
         public string DisplayName => Type.DisplayName;
         public bool IsBuiltIn => Type.IsBuiltIn;
-        public bool HasToggle => Type.HasToggle;
-        public bool CanToggle => HDSettings.Components.ToggableIcons;
+        public bool CanToggle => Type.HasToggle;
 
         public bool Active { get; private set; }
 
@@ -79,7 +77,7 @@ namespace HierarchyDecorator
         {
             // Default as enabled 
 
-            if (IsNullComponent || !HasToggle)
+            if (IsNullComponent || !Type.HasToggle)
             {
                 return true;
             }
@@ -99,7 +97,7 @@ namespace HierarchyDecorator
 
         public void SetActive(bool active)
         {
-            if (!CanToggle || !CanToggle)
+            if (!CanToggle)
             {
                 return;
             }

--- a/HierarchyDecorator/Scripts/Editor/ComponentItem.cs
+++ b/HierarchyDecorator/Scripts/Editor/ComponentItem.cs
@@ -22,7 +22,6 @@ namespace HierarchyDecorator
         public string DisplayName => Type.DisplayName;
         public bool IsBuiltIn => Type.IsBuiltIn;
         public bool HasToggle => Type.HasToggle;
-        public bool ClickToToggleComponent => HDSettings.Components.ClickToToggleComponent;
 
         public bool Active { get; private set; }
 

--- a/HierarchyDecorator/Scripts/Editor/ComponentItem.cs
+++ b/HierarchyDecorator/Scripts/Editor/ComponentItem.cs
@@ -6,9 +6,10 @@ namespace HierarchyDecorator
     public class ComponentItem
     {
         // --- Properties
+        public Settings HDSettings => HierarchyDecorator.Settings;
 
         public Component Component { get; private set; }
-        public ComponentType Type => GetComponentInfo(HierarchyDecorator.Settings);
+        public ComponentType Type => GetComponentInfo(HDSettings);
         public bool IsNullComponent { get; private set; }
 
         public readonly bool IsBehaviour;
@@ -20,7 +21,8 @@ namespace HierarchyDecorator
 
         public string DisplayName => Type.DisplayName;
         public bool IsBuiltIn => Type.IsBuiltIn;
-        public bool CanToggle => Type.HasToggle;
+        public bool HasToggle => Type.HasToggle;
+        public bool CanToggle => HDSettings.Components.ToggableIcons;
 
         public bool Active { get; private set; }
 
@@ -77,7 +79,7 @@ namespace HierarchyDecorator
         {
             // Default as enabled 
 
-            if (IsNullComponent || !Type.HasToggle)
+            if (IsNullComponent || !HasToggle)
             {
                 return true;
             }
@@ -97,7 +99,7 @@ namespace HierarchyDecorator
 
         public void SetActive(bool active)
         {
-            if (!CanToggle)
+            if (!CanToggle || !CanToggle)
             {
                 return;
             }

--- a/HierarchyDecorator/Scripts/Editor/ComponentItem.cs
+++ b/HierarchyDecorator/Scripts/Editor/ComponentItem.cs
@@ -22,7 +22,7 @@ namespace HierarchyDecorator
         public string DisplayName => Type.DisplayName;
         public bool IsBuiltIn => Type.IsBuiltIn;
         public bool HasToggle => Type.HasToggle;
-        public bool CanToggle => HDSettings.Components.ToggableIcons;
+        public bool ClickToToggleComponent => HDSettings.Components.ClickToToggleComponent;
 
         public bool Active { get; private set; }
 
@@ -59,7 +59,7 @@ namespace HierarchyDecorator
         {
             if (IsNullComponent)
                 return null;
-            
+
             var type = Component.GetType();
             if (settings.Components.TryGetComponent(type, out ComponentType c))
             {
@@ -74,7 +74,7 @@ namespace HierarchyDecorator
 
             return c;
         }
-    
+
         private bool GetActiveState()
         {
             // Default as enabled 
@@ -99,17 +99,12 @@ namespace HierarchyDecorator
 
         public void SetActive(bool active)
         {
-            if (!CanToggle || !CanToggle)
+            if (Active != active)
             {
-                return;
+                Active = active;
+                Type.ToggleProperty.SetValue(Component, active);
+                EditorUtility.SetDirty(Component.gameObject);
             }
-			
-			if (Active != active)
-			{
-				Active = active;
-				Type.ToggleProperty.SetValue(Component, active);
-				EditorUtility.SetDirty(Component.gameObject);
-			}
         }
 
         public void UpdateActiveState()

--- a/HierarchyDecorator/Scripts/Editor/Data/ComponentData.cs
+++ b/HierarchyDecorator/Scripts/Editor/Data/ComponentData.cs
@@ -61,7 +61,6 @@ namespace HierarchyDecorator
         // --- Settings
 
         [SerializeField] private bool enableIcons = true;
-        [SerializeField, Tooltip("Will clicking the icon toggle the component")] private bool togglableIcons = true;
 
         [SerializeField] private bool showMissingScriptWarning = true;
         [SerializeField] private DisplayMode showAll = DisplayMode.Unity | DisplayMode.Custom;
@@ -100,8 +99,6 @@ namespace HierarchyDecorator
         /// Are components enabled?
         /// </summary>
         public bool Enabled => enableIcons;
-        public bool ToggableIcons => togglableIcons;
-
 
         /// <summary>
         /// How scripts are drawn in the hierarchy.

--- a/HierarchyDecorator/Scripts/Editor/Data/ComponentData.cs
+++ b/HierarchyDecorator/Scripts/Editor/Data/ComponentData.cs
@@ -61,6 +61,7 @@ namespace HierarchyDecorator
         // --- Settings
 
         [SerializeField] private bool enableIcons = true;
+        [SerializeField, Tooltip("Will clicking the icon toggle the component")] private bool togglableIcons = true;
 
         [SerializeField] private bool showMissingScriptWarning = true;
         [SerializeField] private DisplayMode showAll = DisplayMode.Unity | DisplayMode.Custom;
@@ -99,6 +100,8 @@ namespace HierarchyDecorator
         /// Are components enabled?
         /// </summary>
         public bool Enabled => enableIcons;
+        public bool ToggableIcons => togglableIcons;
+
 
         /// <summary>
         /// How scripts are drawn in the hierarchy.

--- a/HierarchyDecorator/Scripts/Editor/Data/ComponentData.cs
+++ b/HierarchyDecorator/Scripts/Editor/Data/ComponentData.cs
@@ -13,7 +13,7 @@ namespace HierarchyDecorator
         /// Draw both MonoBehaviours and built in.
         /// </summary>
         Unity = 1,
-        
+
         /// <summary>
         /// Display MonoBehaviours
         /// </summary>
@@ -61,7 +61,7 @@ namespace HierarchyDecorator
         // --- Settings
 
         [SerializeField] private bool enableIcons = true;
-        [SerializeField, Tooltip("Will clicking the icon toggle the component")] private bool togglableIcons = true;
+        [SerializeField, Tooltip("Will clicking the icon toggle the component")] private bool clickToToggleComponent = true;
 
         [SerializeField] private bool showMissingScriptWarning = true;
         [SerializeField] private DisplayMode showAll = DisplayMode.Unity | DisplayMode.Custom;
@@ -102,9 +102,9 @@ namespace HierarchyDecorator
         public bool Enabled => enableIcons;
 
         /// <summary>
-        /// Are components toggable?
+        /// Are components toggable when clicked?
         /// </summary>
-        public bool ToggableIcons => togglableIcons;
+        public bool ClickToToggleComponent => clickToToggleComponent;
 
 
         /// <summary>
@@ -196,7 +196,7 @@ namespace HierarchyDecorator
                 string category = GetTypeCategory(type);
 
                 // If the component does not already exist in a group, create one
-                
+
                 if (!TryGetComponent(type, out ComponentType component))
                 {
                     component = new ComponentType(type, true);
@@ -221,7 +221,7 @@ namespace HierarchyDecorator
 
             bool IsDirty()
             {
-                return 
+                return
                     allTypes.Length != unityCount ||    // Internal types changed
                     unityGroups.Length == 0;            // No initialization so far
             }
@@ -315,7 +315,7 @@ namespace HierarchyDecorator
             {
                 return false;
             }
-            
+
             return RegisterCustomComponent(type);
         }
 
@@ -378,7 +378,7 @@ namespace HierarchyDecorator
         /// <param name="component">The component returned if one is found. Otherwise will be null.</param>
         /// <returns>Returns true if a component was found, otherwise will return false.</returns>
         public bool TryGetComponent(Type type, out ComponentType component)
-        {  
+        {
             // If the given type is null, there is nothing to look for
 
             if (type == null)
@@ -390,7 +390,7 @@ namespace HierarchyDecorator
             for (int i = 0; i < unityGroups.Length; i++)
             {
                 ComponentGroup group = unityGroups[i];
-                
+
                 if (group.TryGetComponent(type, out component))
                 {
                     return true;
@@ -445,7 +445,7 @@ namespace HierarchyDecorator
         private string GetTypeCategory(Type type)
         {
             // Cannot categorize null type.
-            
+
             if (type == null)
             {
                 return null;
@@ -454,7 +454,7 @@ namespace HierarchyDecorator
             foreach (var filter in ComponentFilters)
             {
                 // Return the filter name if the type is valid
-                
+
                 if (filter.IsValidFilter(type))
                 {
                     return filter.Name;
@@ -462,7 +462,7 @@ namespace HierarchyDecorator
             }
 
             // Return the default filter, so the type can still be categorized
-           
+
             return DefaultFilter.Name;
         }
     }

--- a/HierarchyDecorator/Scripts/Editor/Data/ComponentData.cs
+++ b/HierarchyDecorator/Scripts/Editor/Data/ComponentData.cs
@@ -102,7 +102,7 @@ namespace HierarchyDecorator
         public bool Enabled => enableIcons;
 
         /// <summary>
-        /// Are components toggable when clicked?
+        /// Are components toggleable when clicked?
         /// </summary>
         public bool ClickToToggleComponent => clickToToggleComponent;
 

--- a/HierarchyDecorator/Scripts/Editor/Data/ComponentData.cs
+++ b/HierarchyDecorator/Scripts/Editor/Data/ComponentData.cs
@@ -100,6 +100,10 @@ namespace HierarchyDecorator
         /// Are components enabled?
         /// </summary>
         public bool Enabled => enableIcons;
+
+        /// <summary>
+        /// Are components toggable?
+        /// </summary>
         public bool ToggableIcons => togglableIcons;
 
 

--- a/HierarchyDecorator/Scripts/Editor/Hierarchy/Info/ComponentIconInfo.cs
+++ b/HierarchyDecorator/Scripts/Editor/Hierarchy/Info/ComponentIconInfo.cs
@@ -125,7 +125,7 @@ namespace HierarchyDecorator
 
         private void DrawComponentIcon(Rect rect, ComponentItem item)
         {
-            if (item.HasToggle)
+            if (item.CanToggle)
             {
                 DrawComponentToggle(rect, item);
             }

--- a/HierarchyDecorator/Scripts/Editor/Hierarchy/Info/ComponentIconInfo.cs
+++ b/HierarchyDecorator/Scripts/Editor/Hierarchy/Info/ComponentIconInfo.cs
@@ -125,7 +125,7 @@ namespace HierarchyDecorator
 
         private void DrawComponentIcon(Rect rect, ComponentItem item)
         {
-            if (item.CanToggle)
+            if (item.HasToggle)
             {
                 DrawComponentToggle(rect, item);
             }

--- a/HierarchyDecorator/Scripts/Editor/Hierarchy/Info/ComponentIconInfo.cs
+++ b/HierarchyDecorator/Scripts/Editor/Hierarchy/Info/ComponentIconInfo.cs
@@ -101,7 +101,7 @@ namespace HierarchyDecorator
                 }
                 else // Draw
                 {
-                    DrawComponentIcon(rect, component);
+                    DrawComponentIcon(rect, component, settings);
                     rect.x -= INDENT_SIZE;
                 }
             }
@@ -123,9 +123,9 @@ namespace HierarchyDecorator
 
         // GUI
 
-        private void DrawComponentIcon(Rect rect, ComponentItem item)
+        private void DrawComponentIcon(Rect rect, ComponentItem item, Settings settings)
         {
-            if (item.HasToggle && item.ClickToToggleComponent)
+            if (item.HasToggle && settings.Components.ClickToToggleComponent)
             {
                 DrawComponentToggle(rect, item);
             }

--- a/HierarchyDecorator/Scripts/Editor/Hierarchy/Info/ComponentIconInfo.cs
+++ b/HierarchyDecorator/Scripts/Editor/Hierarchy/Info/ComponentIconInfo.cs
@@ -21,12 +21,12 @@ namespace HierarchyDecorator
 #if UNITY_2019_1_OR_NEWER
         private readonly GUIContent warningGUI = EditorGUIUtility.IconContent("warning");
 #else
-        private readonly GUIContent warningGUI = EditorGUIUtility.IconContent ("console.warnicon");
+        private readonly GUIContent warningGUI = EditorGUIUtility.IconContent("console.warnicon");
 #endif
         protected override void OnDrawInit(HierarchyItem item, Settings settings)
         {
             requireWarning = false;
-            
+
             List<ComponentItem> newComponents = new List<ComponentItem>();
             foreach (ComponentItem component in item.Components.GetItems())
             {
@@ -125,7 +125,7 @@ namespace HierarchyDecorator
 
         private void DrawComponentIcon(Rect rect, ComponentItem item)
         {
-            if (item.HasToggle)
+            if (item.HasToggle && item.ClickToToggleComponent)
             {
                 DrawComponentToggle(rect, item);
             }

--- a/HierarchyDecorator/Scripts/Editor/Tabs/IconTab.cs
+++ b/HierarchyDecorator/Scripts/Editor/Tabs/IconTab.cs
@@ -86,7 +86,7 @@ namespace HierarchyDecorator
 #if UNITY_2019_1_OR_NEWER
             private static readonly GUIContent WarningGUI = new GUIContent(EditorGUIUtility.IconContent("warning"));
 #else
-            private static readonly GUIContent WarningGUI = EditorGUIUtility.IconContent ("console.warnicon");
+            private static readonly GUIContent WarningGUI = EditorGUIUtility.IconContent("console.warnicon");
 #endif
 
             public static readonly GUIContent EmptyComponent = new GUIContent("<No Component>", WarningGUI.image);
@@ -175,7 +175,7 @@ namespace HierarchyDecorator
             display.ToggleStyle = Style.ToolbarButtonLeft;
 
             CreateDrawableGroup("Settings")
-                .RegisterSerializedProperty(serializedTab, "enableIcons", "togglableIcons", "stackDuplicateIcons", "showMissingScriptWarning");
+                .RegisterSerializedProperty(serializedTab, "enableIcons", "clickToToggleComponent", "stackDuplicateIcons", "showMissingScriptWarning");
         }
 
         // Methods
@@ -240,7 +240,7 @@ namespace HierarchyDecorator
             names.Add("");
             groupNames = names.ToArray();
             Array.Sort(groupNames);
-            
+
             // Assign global group to 'All'
 
             groupNames[0] = Labels.EXCLUDED_COMPONENTS_LABEL;
@@ -805,7 +805,7 @@ namespace HierarchyDecorator
                         if (commandName == "ObjectSelectorUpdated")
                         {
                             MonoScript script = EditorGUIUtility.GetObjectPickerObject() as MonoScript;
-                            
+
                             if (component.Type != script.GetClass())
                             {
                                 group.Update(component, script);

--- a/HierarchyDecorator/Scripts/Editor/Tabs/IconTab.cs
+++ b/HierarchyDecorator/Scripts/Editor/Tabs/IconTab.cs
@@ -175,7 +175,7 @@ namespace HierarchyDecorator
             display.ToggleStyle = Style.ToolbarButtonLeft;
 
             CreateDrawableGroup("Settings")
-                .RegisterSerializedProperty(serializedTab, "enableIcons", "stackDuplicateIcons", "showMissingScriptWarning");
+                .RegisterSerializedProperty(serializedTab, "enableIcons", "togglableIcons", "stackDuplicateIcons", "showMissingScriptWarning");
         }
 
         // Methods

--- a/HierarchyDecorator/Scripts/Editor/Tabs/IconTab.cs
+++ b/HierarchyDecorator/Scripts/Editor/Tabs/IconTab.cs
@@ -175,7 +175,7 @@ namespace HierarchyDecorator
             display.ToggleStyle = Style.ToolbarButtonLeft;
 
             CreateDrawableGroup("Settings")
-                .RegisterSerializedProperty(serializedTab, "enableIcons", "togglableIcons", "stackDuplicateIcons", "showMissingScriptWarning");
+                .RegisterSerializedProperty(serializedTab, "enableIcons", "stackDuplicateIcons", "showMissingScriptWarning");
         }
 
         // Methods


### PR DESCRIPTION
Hello!
I've added a new setting in the Settings, which is called ***Toggable Icons***, what this will do is let you have the option to have components icons let you disable/enable the component.

I like that you can see which components you have in each game object, but for me personally (and maybe others), I just like the visuals. 

https://github.com/user-attachments/assets/611381a5-5cf5-43ef-99c8-0be77b61f501

(Oh, and about the first 3 commits that are just commit, then revert, and then revert the revert, this is my first time doing a pull request, and I wasn't sure how to do it, but I figured it out!)