### PR TITLE
Bugfix: Sometimes, immediately after opening a project, an exceptions keep occurring and HierarchyDecorator does not work properly.

### DIFF
--- a/HierarchyDecorator/Scripts/Editor/Tabs/CategoryFilter.cs
+++ b/HierarchyDecorator/Scripts/Editor/Tabs/CategoryFilter.cs
@@ -33,6 +33,8 @@ namespace HierarchyDecorator
 
                 case FilterType.TYPE:
                     Type baseType = Type.GetType (Filter);
+					if (baseType == null)
+						return false;
                     return type.IsAssignableFrom (baseType) || type.IsSubclassOf (baseType);
             }
 

--- a/HierarchyDecorator/Scripts/Editor/Tabs/CategoryFilter.cs
+++ b/HierarchyDecorator/Scripts/Editor/Tabs/CategoryFilter.cs
@@ -33,8 +33,8 @@ namespace HierarchyDecorator
 
                 case FilterType.TYPE:
                     Type baseType = Type.GetType (Filter);
-					if (baseType == null)
-						return false;
+                    if (baseType == null)
+                        return false;
                     return type.IsAssignableFrom (baseType) || type.IsSubclassOf (baseType);
             }
 


### PR DESCRIPTION
**Current Unity version used**
6000.0.42f1

**Describe the bug**
Occasionally, when open a project, an exceptions keep occurring and HierarchyDecorator does not work properly.
It also resolves the issue where errors continue to occur when the Settings file is deleted from the Unity Editor.

Here is the exception log.
```c#
(Filename: Assets/Scripts/Editor/Tabs/CategoryFilter.cs Line: 36)

ArgumentNullException: Value cannot be null.
Parameter name: type
  at System.RuntimeType.IsSubclassOf (System.Type type) [0x00003] in <13c0c460649d4ce49f991e2c222fa635>:0 
  at HierarchyDecorator.CategoryFilter.IsValidFilter (System.Type type) [0x0003b] in C:\user\projects\...\Assets\Scripts\Editor\Tabs\CategoryFilter.cs:36 
  at HierarchyDecorator.ComponentData.GetTypeCategory (System.Type type) [0x0001d] in C:\user\projects\...\Assets\Scripts\Editor\Data\ComponentData.cs:458 
  at HierarchyDecorator.ComponentData.UpdateData (System.Boolean forceDirty) [0x000a8] in C:\user\projects\...\Assets\Scripts\Editor\Data\ComponentData.cs:196 
  at HierarchyDecorator.Settings.OnAfterDeserialize () [0x00000] in C:\user\projects\...\Assets\Scripts\Editor\Settings.cs:53 
```
