### PR TITLE
 bugfix: Attaching a uGUI component replaces the Transform with a RectTransform, which results in the loss of the reference

### DIFF
--- a/HierarchyDecorator/Scripts/Editor/HierarchyItem.cs
+++ b/HierarchyDecorator/Scripts/Editor/HierarchyItem.cs
@@ -21,7 +21,7 @@ namespace HierarchyDecorator
         /// <summary>
         /// The <see cref="GameObject"/> transform for this item. Cached for performance.
         /// </summary>
-        public readonly Transform Transform;
+        public Transform Transform;
 
         // --- Properties
 

--- a/HierarchyDecorator/Scripts/Editor/HierarchyManager.cs
+++ b/HierarchyDecorator/Scripts/Editor/HierarchyManager.cs
@@ -156,7 +156,12 @@ namespace HierarchyDecorator
                 item = new HierarchyItem(id, instance);
                 lookup.Add(id, item);
             }
-
+            else
+            {
+                // Fix broken references caused by attaching uGUI components.
+                if (item.Transform == null)
+                    item.Transform = instance.transform;
+            }
             return item;
         }
 


### PR DESCRIPTION
This issue can occur with any uGUI component, but attaching a Canvas component will reproduce it. It triggers a MissingReferenceException and corrupts the Hierarchy view.