### PR TITLE
Feature: Added a feature that allows selecting the active toggle type in the Hierarchy view

### DIFF
--- a/HierarchyDecorator/Scripts/Editor/Data/GlobalData.cs
+++ b/HierarchyDecorator/Scripts/Editor/Data/GlobalData.cs
@@ -30,6 +30,8 @@ namespace HierarchyDecorator
         // Toggles
 
         public bool showActiveToggles = true;
+        public enum ToggleType {Checkbox, Dot}
+        public ToggleType activeToggleType = ToggleType.Checkbox;
 
         [Tooltip("Clicking and dragging over check boxes to toggle them.")]
         public bool activeSwiping = true;

--- a/HierarchyDecorator/Scripts/Editor/Hierarchy/Drawers/ToggleDrawer.cs
+++ b/HierarchyDecorator/Scripts/Editor/Hierarchy/Drawers/ToggleDrawer.cs
@@ -17,6 +17,10 @@ namespace HierarchyDecorator
         private bool isHoldingMouse = false;
         private bool isPressingShift = false;
 
+        // --- Toggle
+
+        private GUIStyle currentToggleOnStyle, currentToggleOffStyle;
+
         // Target data for settings based off the first instance selected
         
         private GameObject targetInstance = null;
@@ -68,10 +72,10 @@ namespace HierarchyDecorator
 
             // Draw toggles
 
-            DrawToggles (rect, instance, !settings.globalData.activeSwiping);
+            DrawToggles (rect, instance, settings.globalData.activeToggleType, !settings.globalData.activeSwiping);
         }
 
-        private void DrawToggles(Rect rect, GameObject instance, bool canUpdate = true)
+        private void DrawToggles(Rect rect, GameObject instance, GlobalData.ToggleType toggleType, bool canUpdate = true)
         {
             bool isActive = instance.activeSelf;
 
@@ -80,7 +84,28 @@ namespace HierarchyDecorator
             EditorGUI.BeginChangeCheck ();
             {
 #if UNITY_2019_1_OR_NEWER
-                isActive = EditorGUI.Toggle (rect, isActive, isActive ? Style.Toggle : Style.ToggleMixed);
+                switch (toggleType)
+                {
+                    case GlobalData.ToggleType.Checkbox:
+                        _RecreateStyleIfNeeded(Style.Toggle, Style.ToggleMixed);
+                        isActive = EditorGUI.Toggle(rect, isActive, isActive ? currentToggleOnStyle : currentToggleOffStyle);
+                        break;
+                    case GlobalData.ToggleType.Dot:
+                        _RecreateStyleIfNeeded(Style.ToggleDot, Style.ToggleDot);
+                        var color = GUI.color;
+                        if (!isActive)
+                            GUI.color = new Color(GUI.color.r, GUI.color.g, GUI.color.b, 0.15f);
+                        isActive = EditorGUI.Toggle(rect, isActive, isActive ? currentToggleOnStyle : currentToggleOffStyle);
+                        GUI.color = color;
+                        break;
+                }
+                void _RecreateStyleIfNeeded(GUIStyle on, GUIStyle off)
+                {
+                    if (currentToggleOnStyle == null || currentToggleOnStyle.name != on.name)
+                        currentToggleOnStyle = new GUIStyle(on);
+                    if (currentToggleOffStyle == null || currentToggleOffStyle.name != off.name)
+                        currentToggleOffStyle = new GUIStyle(off);
+                }
 #else
                 isActive = EditorGUI.Toggle (rect, isActive);
 #endif

--- a/HierarchyDecorator/Scripts/Editor/Style.cs
+++ b/HierarchyDecorator/Scripts/Editor/Style.cs
@@ -35,7 +35,7 @@ namespace HierarchyDecorator
 
         // --- Hierarchy Styles
 
-        public static readonly GUIStyle Toggle;
+        public static readonly GUIStyle Toggle, ToggleDot;
         public static readonly GUIStyle ToggleMixed;
 
         // --- Fields
@@ -196,7 +196,15 @@ namespace HierarchyDecorator
             };
 
             // Hierarchy Styles
-
+            ToggleDot = new GUIStyle(GUI.skin.button)
+            {
+                name = "toggle-dot", // require as unique id for recreate
+                normal =
+                {
+                    textColor = EditorStyles.label.normal.textColor,
+                    background = EditorGUIUtility.Load("DotFill") as Texture2D,
+                },
+            };
             Toggle = new GUIStyle ("OL Toggle")
             {
                 normal =

--- a/HierarchyDecorator/Scripts/Editor/Tabs/GeneralTab.cs
+++ b/HierarchyDecorator/Scripts/Editor/Tabs/GeneralTab.cs
@@ -14,7 +14,7 @@ namespace HierarchyDecorator
             // --- General Features
 
             CreateDrawableGroup("Toggles")
-                .RegisterSerializedProperty(serializedTab, "showActiveToggles", "activeSwiping", "swipeSameState", "swipeSelectionOnly", "depthMode");
+                .RegisterSerializedProperty(serializedTab, "showActiveToggles", "activeToggleType", "activeSwiping", "swipeSameState", "swipeSelectionOnly", "depthMode");
 
             // --- Layers
 

--- a/HierarchyDecorator/Scripts/Editor/Tabs/StyleTab.cs
+++ b/HierarchyDecorator/Scripts/Editor/Tabs/StyleTab.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEditor;
 using UnityEditorInternal;
-using static UnityEngine.GraphicsBuffer;
 
 namespace HierarchyDecorator
 {


### PR DESCRIPTION
This is a pull request for Issue #114.
I tried to keep the code as flexible as possible, in case we want to add more icon types in the future. "DotFill" might not be available in Unity 2018, but I believe it just won’t display—it shouldn’t cause any errors or crashes.

P.S.
Latest code in the master branch was causing some errors in Unity 2018 due to the use of APIs that don't exist there. One of the issues was a namespace reference that didn’t seem to be used, so I went ahead and removed it in this commit.

https://github.com/user-attachments/assets/747f9dce-0862-4890-9f7f-ef0e8f541ef8

