### PR TITLE
Added missing prefab asset coloring

### DIFF
--- a/HierarchyDecorator/Scripts/Editor/HierarchyGUI.cs
+++ b/HierarchyDecorator/Scripts/Editor/HierarchyGUI.cs
@@ -8,6 +8,7 @@ namespace HierarchyDecorator
         private static GUIStyle TextStyle = new GUIStyle(EditorStyles.label);
         private static readonly Color DarkModeText = new Color(0.48f, 0.67f, 0.95f, 1f);
         private static readonly Color WhiteModeText = new Color(0.1f, 0.3f, 0.7f, 1f);
+        private static readonly Color MissingPrefabText = new Color(0.95f, 0.55f, 0.55f);
 
         public static void DrawHierarchyStyle(HierarchyStyle style, Rect styleRect, Rect labelRect, string label, bool removePrefix = true)
         {
@@ -29,8 +30,9 @@ namespace HierarchyDecorator
             // Get the content needed for the icon
 
             bool isPrefab = item.IsPrefab;
-            bool isPrefabParent = item.PrefabInfo == PrefabInfo.Root;
-
+            bool isPrefabParent = item.PrefabInfo == PrefabInfo.Root; 
+            bool isPrefabMissing = item.PrefabTypeInfo == PrefabAssetType.MissingAsset;
+           
             GUIContent content = GetStandardContent (instance, isPrefabParent);
 
             // Handle colours
@@ -38,10 +40,13 @@ namespace HierarchyDecorator
             Color textColour = EditorStyles.label.normal.textColor;
             if (isPrefab)
             {
-                textColour = (EditorGUIUtility.isProSkin) ? DarkModeText : WhiteModeText;
+                if (isPrefabMissing)
+                    textColour = MissingPrefabText;
+                else
+                    textColour = (EditorGUIUtility.isProSkin) ? DarkModeText : WhiteModeText;
             }
 
-            if (Selection.Contains(instance))
+            if (Selection.Contains(instance) && ! isPrefabMissing)
             {
                 textColour = Color.white;
             }
@@ -103,7 +108,7 @@ namespace HierarchyDecorator
                     image = GetPrefabIcon(instance)
                 };
             }
-            
+
             return EditorGUIUtility.IconContent(GetGameObjectIcon(Selection.Contains(instance)));
         }
 
@@ -138,7 +143,7 @@ namespace HierarchyDecorator
         }
 
         private static Texture2D GetPrefabIcon(GameObject instance)
-        {
+        { 
             return PrefabUtility.GetIconForGameObject(instance);
         }
     }

--- a/HierarchyDecorator/Scripts/Editor/HierarchyItem.cs
+++ b/HierarchyDecorator/Scripts/Editor/HierarchyItem.cs
@@ -46,6 +46,11 @@ namespace HierarchyDecorator
         public bool HasParent => Transform.parent != null;
 
         /// <summary>
+        /// The type of prefab asset.
+        /// </summary>
+        public PrefabAssetType PrefabTypeInfo { get; private set; }
+
+        /// <summary>
         /// The prefab state.
         /// </summary>
         public PrefabInfo PrefabInfo { get; private set; }
@@ -53,7 +58,7 @@ namespace HierarchyDecorator
         /// <summary>
         /// Is this item part of a prefab?
         /// </summary>
-        public bool IsPrefab => PrefabInfo != PrefabInfo.None;
+        public bool IsPrefab => PrefabInfo != PrefabInfo.None; 
 
         /// <summary>
         /// The display string for the item.
@@ -83,7 +88,7 @@ namespace HierarchyDecorator
             {
                 return PrefabInfo.None;
             }
-
+             
             return PrefabUtility.GetNearestPrefabInstanceRoot(GameObject) == GameObject
                 ? PrefabInfo.Root
                 : PrefabInfo.Part;
@@ -95,6 +100,8 @@ namespace HierarchyDecorator
         public void OnGUIBegin()
         {
             PrefabInfo = GetPrefabInfo();
+            PrefabTypeInfo = PrefabInfo == PrefabInfo.None ?
+                PrefabAssetType.NotAPrefab : PrefabTypeInfo = PrefabUtility.GetPrefabAssetType(GameObject);
             Components.Validate(GameObject);
         }
 


### PR DESCRIPTION
When a prefab asset was deleted or missing, there was no indication of it in the hierarchy, and it was the same as any other prefab.
Applied correct color coding when a prefab is missing.

Before:
![image](https://github.com/user-attachments/assets/7ca06d65-b133-432f-b1f9-1318b92da180)

After:
![image](https://github.com/user-attachments/assets/df2f9060-1c85-48b3-b80a-8c90ba567309)
