### PR TITLE
Add triangle counter field for mesh GameObjects in hierarchy

### DIFF
--- a/HierarchyDecorator/Scripts/Editor/Data/GlobalData.cs
+++ b/HierarchyDecorator/Scripts/Editor/Data/GlobalData.cs
@@ -51,6 +51,7 @@ namespace HierarchyDecorator
         public bool showTags = true;
         public bool showLayers = true;
         public bool applyChildLayers = true;
+        public bool showTriangleCounts = true;
 
         // Components 
 

--- a/HierarchyDecorator/Scripts/Editor/Data/HierarchyStyleData.cs
+++ b/HierarchyDecorator/Scripts/Editor/Data/HierarchyStyleData.cs
@@ -35,6 +35,7 @@ namespace HierarchyDecorator
         public bool displayTags = true;
         public bool displayLayers = true;
         public bool displayIcons = true;
+        public bool displayTriangleCounts = true;
 
         public List<HierarchyStyle> styles = new List<HierarchyStyle> ()
         {

--- a/HierarchyDecorator/Scripts/Editor/Hierarchy/Info/MeshInfo.cs
+++ b/HierarchyDecorator/Scripts/Editor/Hierarchy/Info/MeshInfo.cs
@@ -1,0 +1,93 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace HierarchyDecorator
+{
+    public class MeshInfo : HierarchyInfo
+    {
+        private const int LABEL_GRID_SIZE = 2;
+
+        // --- Settings
+
+        private bool triangleCountEnabled;
+
+        // --- Cached Data
+
+        private int triangleCount;
+
+        // --- Methods
+
+        protected override void OnDrawInit(HierarchyItem item, Settings settings)
+        {
+            triangleCount = GetTriangleCount(item.GameObject);
+        }
+
+        protected override bool DrawerIsEnabled(HierarchyItem item, Settings settings)
+        {
+            triangleCountEnabled = settings.globalData.showTriangleCounts;
+
+            if (settings.styleData.HasStyle(item.DisplayName))
+            {
+                triangleCountEnabled &= settings.styleData.displayTriangleCounts;
+            }
+
+            return triangleCountEnabled;
+        }
+
+        protected override void DrawInfo(Rect rect, HierarchyItem item, Settings settings)
+        {
+            DrawTriangleCount(rect);
+        }
+
+        protected override int CalculateGridCount()
+        {
+            return triangleCount > 0 ? LABEL_GRID_SIZE : 0;
+        }
+
+        protected override bool ValidateGrid()
+        {
+            if (GridCount < LABEL_GRID_SIZE)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        // - Drawing elements
+
+        private void DrawTriangleCount(Rect rect)
+        {
+            rect.x = rect.xMax - LABEL_GRID_SIZE * INDENT_SIZE;
+            rect.width = LABEL_GRID_SIZE * INDENT_SIZE;
+
+            GUIStyle SmallDropdownRightAligned = new GUIStyle(Style.SmallDropdown)
+            {
+                alignment = TextAnchor.MiddleRight
+            };
+
+            EditorGUI.LabelField(rect, triangleCount.ToString(), SmallDropdownRightAligned);
+        }
+
+        // - Helpers
+
+        private int GetTriangleCount(GameObject obj)
+        {
+            int total = 0;
+
+            MeshFilter mf = obj.GetComponent<MeshFilter>();
+            if (mf != null && mf.sharedMesh != null)
+            {
+                total += mf.sharedMesh.triangles.Length / 3;
+            }
+
+            SkinnedMeshRenderer smr = obj.GetComponent<SkinnedMeshRenderer>();
+            if (smr != null && smr.sharedMesh != null)
+            {
+                total += smr.sharedMesh.triangles.Length / 3;
+            }
+
+            return total;
+        }
+    }
+}

--- a/HierarchyDecorator/Scripts/Editor/Hierarchy/Info/MeshInfo.cs.meta
+++ b/HierarchyDecorator/Scripts/Editor/Hierarchy/Info/MeshInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f446333cd90b38d40a4a27a0fa01e021
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/HierarchyDecorator/Scripts/Editor/HierarchyManager.cs
+++ b/HierarchyDecorator/Scripts/Editor/HierarchyManager.cs
@@ -37,6 +37,7 @@ namespace HierarchyDecorator
         private static HierarchyInfo[] Info = new HierarchyInfo[]
         {
             new TagLayerInfo(),
+            new MeshInfo(),
             new ComponentIconInfo()
         };
 

--- a/HierarchyDecorator/Scripts/Editor/Tabs/GeneralTab.cs
+++ b/HierarchyDecorator/Scripts/Editor/Tabs/GeneralTab.cs
@@ -8,6 +8,7 @@ namespace HierarchyDecorator
     {
         private string[] TagFields = new[] { "showTags" };
         private string[] LayerFields = new[] { "showLayers", "applyChildLayers" };
+        private string[] TriangleFields = new[] { "showTriangleCounts" };
 
         public GeneralTab(Settings settings, SerializedObject serializedSettings) : base (settings, serializedSettings, "globalData", "General", "d_CustomTool")
         {
@@ -18,9 +19,10 @@ namespace HierarchyDecorator
 
             // --- Layers
 
-            CreateDrawableGroup("Tags & Layers")
+            CreateDrawableGroup("Fields")
                 .RegisterSerializedProperty(serializedTab, TagFields)
-                .RegisterSerializedProperty(serializedTab, LayerFields).Space()
+                .RegisterSerializedProperty(serializedTab, LayerFields)
+                .RegisterSerializedProperty(serializedTab, TriangleFields).Space()
                 .RegisterSerializedProperty(serializedTab, "tagLayerLayout");
 
             // --- Breadcrumbs

--- a/HierarchyDecorator/Scripts/Editor/Tabs/StyleTab.cs
+++ b/HierarchyDecorator/Scripts/Editor/Tabs/StyleTab.cs
@@ -70,7 +70,7 @@ namespace HierarchyDecorator
                 .RegisterSerializedGroup(lightModeBack, "Light Mode", "colorOne", "colorTwo");
 
             CreateDrawableGroup ("Styles")
-                .RegisterSerializedProperty(serializedTab, "displayTags", "displayLayers", "displayIcons")
+                .RegisterSerializedProperty(serializedTab, "displayTags", "displayLayers", "displayIcons", "displayTriangleCounts")
                 .RegisterReorderable (styleList);
         }
 


### PR DESCRIPTION
Adds a new triangle count display feature that shows the number of triangles for GameObjects with MeshFilter or SkinnedMeshRenderer components in the Unity hierarchy window.

I wasn't sure if it this would make more sense in icon components or it's own field but for now I made it it's own field since it was more simple. 

<img width="454" height="537" alt="image" src="https://github.com/user-attachments/assets/cb64fcec-0515-4994-833e-1676c5b6cf52" />
