### PR TITLE
Handle cases where name matches prefix exactly

### DIFF
--- a/HierarchyDecorator/Scripts/Editor/Data/HierarchyStyleData.cs
+++ b/HierarchyDecorator/Scripts/Editor/Data/HierarchyStyleData.cs
@@ -202,6 +202,9 @@ namespace HierarchyDecorator
                 if (style.noSpaceAfterPrefix)
                     return true;
 
+                if (targetPrefix.Length == style.prefix.Length)
+                    return false; // No point in making an empty row
+
                 if (targetPrefix[style.prefix.Length] == ' ')
                     return true;
             }


### PR DESCRIPTION
GameObjects named `-` or `------` would cause index out of bounds exceptions, breaking the hierarchy past that object.