### PR TITLE
Refactors Unity version checks to 6000_0

### DIFF
--- a/HierarchyDecorator/Scripts/Editor/HierarchyItem.cs
+++ b/HierarchyDecorator/Scripts/Editor/HierarchyItem.cs
@@ -11,7 +11,7 @@ namespace HierarchyDecorator
         /// <summary>
         /// The ID for the hierarchy item.
         /// </summary>
-#if UNITY_6000_4_OR_NEWER
+#if UNITY_6000_0_OR_NEWER
         public readonly EntityId ID;
 #else
         public readonly int ID;
@@ -72,13 +72,13 @@ namespace HierarchyDecorator
         /// <summary>
         /// Create a new HierachyItem instance.
         /// </summary>
-#if UNITY_6000_4_OR_NEWER
+#if UNITY_6000_0_OR_NEWER
         /// <param name="id">The entity ID.</param>
 #else
         /// <param name="id">The instance ID.</param>
 #endif
         /// <param name="instance">The gameobject this iunstance represents.</param>
-#if UNITY_6000_4_OR_NEWER
+#if UNITY_6000_0_OR_NEWER
         public HierarchyItem(EntityId id, GameObject instance)
 #else
         public HierarchyItem(int id, GameObject instance)

--- a/HierarchyDecorator/Scripts/Editor/HierarchyManager.cs
+++ b/HierarchyDecorator/Scripts/Editor/HierarchyManager.cs
@@ -12,7 +12,7 @@ namespace HierarchyDecorator
     {
         // --- Scene Data
 
-#if UNITY_6000_4_OR_NEWER
+#if UNITY_6000_0_OR_NEWER
         private static Dictionary<EntityId, HierarchyItem> lookup = new Dictionary<EntityId, HierarchyItem>();
         public static IReadOnlyDictionary<EntityId, HierarchyItem> Items => lookup;
 #else
@@ -51,7 +51,7 @@ namespace HierarchyDecorator
         {
             lookup.Clear();
 
-#if UNITY_6000_4_OR_NEWER
+#if UNITY_6000_0_OR_NEWER
             EditorApplication.hierarchyWindowItemByEntityIdOnGUI -= OnGUI;
             EditorApplication.hierarchyWindowItemByEntityIdOnGUI += OnGUI;
 #else
@@ -96,7 +96,7 @@ namespace HierarchyDecorator
 
         // - GUI
 
-#if UNITY_6000_4_OR_NEWER
+#if UNITY_6000_0_OR_NEWER
         public static void OnGUI(EntityId id, Rect rect)
 #else
         public static void OnGUI(int id, Rect rect)
@@ -150,13 +150,13 @@ namespace HierarchyDecorator
             HierarchyInfo.ResetIndent();
         }
 
-#if UNITY_6000_4_OR_NEWER
+#if UNITY_6000_0_OR_NEWER
         private static bool TryGetValidInstance(EntityId id, out HierarchyItem item)
 #else
         private static bool TryGetValidInstance(int id, out HierarchyItem item)
 #endif
         {
-#if UNITY_6000_4_OR_NEWER
+#if UNITY_6000_0_OR_NEWER
             GameObject instance = EditorUtility.EntityIdToObject(id) as GameObject;
 #else
             GameObject instance = EditorUtility.InstanceIDToObject(id) as GameObject;
@@ -172,7 +172,7 @@ namespace HierarchyDecorator
             return true;
         }
 
-#if UNITY_6000_4_OR_NEWER
+#if UNITY_6000_0_OR_NEWER
         private static HierarchyItem GetNext(EntityId id, GameObject instance)
 #else
         private static HierarchyItem GetNext(int id, GameObject instance)
@@ -192,7 +192,7 @@ namespace HierarchyDecorator
             return item;
         }
 
-#if UNITY_6000_4_OR_NEWER
+#if UNITY_6000_0_OR_NEWER
         private static void DrawSceneItemHighlight(Rect rect, EntityId id)
 #else
         private static void DrawSceneItemHighlight(Rect rect, int id)
@@ -203,7 +203,7 @@ namespace HierarchyDecorator
             for (int i = 0; i < SceneManager.sceneCount; ++i)
             {
                 var scene = SceneManager.GetSceneAt(i);
-#if UNITY_6000_4_OR_NEWER
+#if UNITY_6000_0_OR_NEWER
                 if (scene.handle.GetRawData() == EntityId.ToULong(id))
 #else
                 if (scene.handle == id)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.wooshii.hierarchydecorator",
   "displayName": "HierarchyDecorator",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "unity": "2018.4",
   "description": "HierarchyDecorator is an extension for the Unity Hierarchy enhancing it's utility.",
   "keywords": [


### PR DESCRIPTION
> [!NOTE]
> In Unity 6000.5.1f1, directives `UNITY_6000_4_OR_NEWER` does not works

Updates hierarchy item and manager classes to support the new Unity versioning scheme:

- Modifies preprocessor directives to target `UNITY_6000_0_OR_NEWER`, ensuring compatibility with the latest Unity versions.