### PR TITLE
Fix "Unity 6.3 LTS - four "does not contain definition" errors on import

### DIFF
--- a/HierarchyDecorator/Scripts/Editor/HierarchyManager.cs
+++ b/HierarchyDecorator/Scripts/Editor/HierarchyManager.cs
@@ -51,7 +51,8 @@ namespace HierarchyDecorator
         {
             lookup.Clear();
 
-#if UNITY_6000_0_OR_NEWER
+
+#if UNITY_6000_4_OR_NEWER || UNITY_6000_5_OR_NEWER
             EditorApplication.hierarchyWindowItemByEntityIdOnGUI -= OnGUI;
             EditorApplication.hierarchyWindowItemByEntityIdOnGUI += OnGUI;
 #else
@@ -96,7 +97,7 @@ namespace HierarchyDecorator
 
         // - GUI
 
-#if UNITY_6000_0_OR_NEWER
+#if UNITY_6000_4_OR_NEWER || UNITY_6000_5_OR_NEWER
         public static void OnGUI(EntityId id, Rect rect)
 #else
         public static void OnGUI(int id, Rect rect)
@@ -203,7 +204,7 @@ namespace HierarchyDecorator
             for (int i = 0; i < SceneManager.sceneCount; ++i)
             {
                 var scene = SceneManager.GetSceneAt(i);
-#if UNITY_6000_0_OR_NEWER
+#if UNITY_6000_4_OR_NEWER || UNITY_6000_5_OR_NEWER
                 if (scene.handle.GetRawData() == EntityId.ToULong(id))
 #else
                 if (scene.handle == id)


### PR DESCRIPTION
Fix [Issue #148](https://github.com/WooshiiDev/HierarchyDecorator/issues/148) by increasing the version of some directives in the HierarchyManager.
I also noticed that #146 (the pull request that appears to be the origin of the bugs) says that "In Unity 6000.5.1f1, directives UNITY_6000_4_OR_NEWER does not work" so I took that into account when implementing the fix.

Tested in 6000.3.21f1, 6000.5.10f1, 6000.6.0b5